### PR TITLE
Feat: 특정 이벤트의 구역별 남은 좌석 반환 (#5)

### DIFF
--- a/src/main/java/com/T82/ticket/controller/SectionController.java
+++ b/src/main/java/com/T82/ticket/controller/SectionController.java
@@ -1,0 +1,24 @@
+package com.T82.ticket.controller;
+
+import com.T82.ticket.dto.response.RestSeatResponseDto;
+import com.T82.ticket.service.SectionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1")
+public class SectionController {
+    private final SectionService sectionService;
+
+    @GetMapping("/events/{eventId}/restseats")
+    @ResponseStatus(HttpStatus.OK)
+    public List<RestSeatResponseDto> getAvailableSeatCountPerSection(@PathVariable(name = "eventId") Long eventId){
+        return sectionService.getAvailableSeatCountPerSection(eventId);
+    };
+}

--- a/src/main/java/com/T82/ticket/dto/response/RestSeatResponseDto.java
+++ b/src/main/java/com/T82/ticket/dto/response/RestSeatResponseDto.java
@@ -1,0 +1,15 @@
+package com.T82.ticket.dto.response;
+
+import com.T82.ticket.global.domain.entity.Section;
+
+public record RestSeatResponseDto (Long sectionId, String name, Long totalSeat, Long restSeat){
+    public static RestSeatResponseDto from(Section section){
+        return new RestSeatResponseDto(
+                section.getSectionId(),
+                section.getName(),
+                section.getTotalSeat(),
+                section.getRestSeat()
+        );
+    }
+}
+

--- a/src/main/java/com/T82/ticket/global/domain/repository/PlaceRepository.java
+++ b/src/main/java/com/T82/ticket/global/domain/repository/PlaceRepository.java
@@ -3,5 +3,8 @@ package com.T82.ticket.global.domain.repository;
 import com.T82.ticket.global.domain.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+
 }

--- a/src/main/java/com/T82/ticket/global/domain/repository/SectionRepository.java
+++ b/src/main/java/com/T82/ticket/global/domain/repository/SectionRepository.java
@@ -2,6 +2,12 @@ package com.T82.ticket.global.domain.repository;
 
 import com.T82.ticket.global.domain.entity.Section;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+    @Query("select s from Section s where s.place.eventId= :eventId")
+    List<Section> findAllByEventId(@Param("eventId")Long evnetId);
 }

--- a/src/main/java/com/T82/ticket/service/SeatService.java
+++ b/src/main/java/com/T82/ticket/service/SeatService.java
@@ -1,0 +1,5 @@
+package com.T82.ticket.service;
+
+public interface SeatService {
+
+}

--- a/src/main/java/com/T82/ticket/service/SeatServiceImpl.java
+++ b/src/main/java/com/T82/ticket/service/SeatServiceImpl.java
@@ -1,0 +1,18 @@
+package com.T82.ticket.service;
+
+import com.T82.ticket.dto.response.RestSeatResponseDto;
+import com.T82.ticket.global.domain.entity.Section;
+import com.T82.ticket.global.domain.repository.SeatRepository;
+import com.T82.ticket.global.domain.repository.SectionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SeatServiceImpl implements SeatService{
+
+}

--- a/src/main/java/com/T82/ticket/service/SectionService.java
+++ b/src/main/java/com/T82/ticket/service/SectionService.java
@@ -1,0 +1,9 @@
+package com.T82.ticket.service;
+
+import com.T82.ticket.dto.response.RestSeatResponseDto;
+
+import java.util.List;
+
+public interface SectionService {
+    List<RestSeatResponseDto> getAvailableSeatCountPerSection(Long eventId);
+}

--- a/src/main/java/com/T82/ticket/service/SectionServiceImpl.java
+++ b/src/main/java/com/T82/ticket/service/SectionServiceImpl.java
@@ -1,0 +1,23 @@
+package com.T82.ticket.service;
+
+import com.T82.ticket.dto.response.RestSeatResponseDto;
+import com.T82.ticket.global.domain.entity.Section;
+import com.T82.ticket.global.domain.repository.SectionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SectionServiceImpl implements SectionService{
+    private final SectionRepository sectionRepository;
+
+    @Override
+    public List<RestSeatResponseDto> getAvailableSeatCountPerSection(Long eventId) {
+        List<Section> allByEventId = sectionRepository.findAllByEventId(eventId);
+        return allByEventId.stream().map(RestSeatResponseDto::from).toList();
+    }
+}

--- a/src/test/java/com/T82/ticket/service/SectionServiceImplTest.java
+++ b/src/test/java/com/T82/ticket/service/SectionServiceImplTest.java
@@ -1,0 +1,66 @@
+package com.T82.ticket.service;
+
+import com.T82.ticket.dto.response.RestSeatResponseDto;
+import com.T82.ticket.global.domain.entity.Place;
+import com.T82.ticket.global.domain.entity.Section;
+import com.T82.ticket.global.domain.repository.PlaceRepository;
+import com.T82.ticket.global.domain.repository.SectionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SectionServiceImplTest {
+
+    @Autowired
+    SectionRepository sectionRepository;
+    @Autowired
+    PlaceRepository placeRepository;
+
+    @Autowired
+    SectionServiceImpl sectionService;
+
+    private Place place;
+
+    @BeforeEach
+    void setUp() {
+        place = new Place(1L,"장소1","주소1",new ArrayList<>());
+        placeRepository.saveAndFlush(place);
+
+        Section section1 = new Section(null, "이벤트이름1", 100L, 80L, 1000L, place, new ArrayList<>());
+        Section section2 = new Section(null, "이벤트이름2", 200L, 150L, 1500L, place, new ArrayList<>());
+        Section section3 = new Section(null, "이벤트이름3", 150L, 50L, 1200L, place, new ArrayList<>());
+
+        sectionRepository.saveAndFlush(section1);
+        sectionRepository.saveAndFlush(section2);
+        sectionRepository.saveAndFlush(section3);
+    }
+
+    @Test
+    @DisplayName("이벤트ID로 이벤트의 모든 구역들의 남은 좌석 가져오기")
+    @Transactional
+    void getAvailableSeatCountPerSectionTest() {
+//    when
+        List<RestSeatResponseDto> availableSeatCountPerSection = sectionService.getAvailableSeatCountPerSection(1L);
+//    then
+        assertNotNull(availableSeatCountPerSection);
+        assertEquals(3, availableSeatCountPerSection.size());
+
+        assertTrue(availableSeatCountPerSection.stream()
+                .anyMatch(dto -> dto.name().equals("이벤트이름1") && dto.restSeat().equals(80L)));
+        assertTrue(availableSeatCountPerSection.stream()
+                .anyMatch(dto -> dto.name().equals("이벤트이름2") && dto.restSeat().equals(150L)));
+        assertTrue(availableSeatCountPerSection.stream()
+                .anyMatch(dto -> dto.name().equals("이벤트이름3") && dto.restSeat().equals(50L)));
+    }
+}


### PR DESCRIPTION
## 개요
특정 이벤트의 모든 구역별 남은 좌석수를 반환하는 기능입니다.

## 주요 변경 사항
- 이벤트의 ID를 Request하면 해당 이벤트의 모든 구역에 대한 남은 좌석 수를 반환하도록 구현하였습니다.

## 기능 설명
1. **이벤트 하나의 모든 구역에 대한 남은 좌석 수 반환**
   - 이벤트 ID를 Long타입으로 제공하면 해당 이벤트의 모든 구역의 남은 좌석 수를 반환합니다.