### PR TITLE
[Feat] 예매가능한 구역별 좌석 리스트 반환 api 스펙 수정

### DIFF
--- a/src/main/java/com/T82/ticket/controller/SeatController.java
+++ b/src/main/java/com/T82/ticket/controller/SeatController.java
@@ -18,8 +18,8 @@ import java.util.List;
 public class SeatController {
     private final SeatService seatService;
 
-    @GetMapping("/section/{sectionId}")
-    public List<AvailableSeatsResponseDto> getAvailableSeats(@PathVariable(name = "sectionId") Long sectionId){
-        return seatService.getAvailableSeats(sectionId);
+    @GetMapping("/events/{eventId}")
+    public List<AvailableSeatsResponseDto> getAvailableSeats(@PathVariable(name = "eventId") Long eventId){
+        return seatService.getAvailableSeats(eventId);
     }
 }

--- a/src/main/java/com/T82/ticket/dto/response/AvailableSeatsResponseDto.java
+++ b/src/main/java/com/T82/ticket/dto/response/AvailableSeatsResponseDto.java
@@ -1,13 +1,17 @@
 package com.T82.ticket.dto.response;
 
 import com.T82.ticket.global.domain.entity.Seat;
+import com.T82.ticket.global.domain.entity.Section;
 
-public record AvailableSeatsResponseDto(Long seatId, Long rowNum, Long columnNum) {
+public record AvailableSeatsResponseDto(Long seatId, Long rowNum, Long columnNum, String name, Long price) {
     public static AvailableSeatsResponseDto from(Seat seat){
+        Section section = seat.getSection();
         return new AvailableSeatsResponseDto(
                 seat.getSeatId(),
                 seat.getRowNum(),
-                seat.getColumnNum()
+                seat.getColumnNum(),
+                section.getName(),
+                section.getPrice()
         );
     }
 }

--- a/src/main/java/com/T82/ticket/global/domain/repository/SeatRepository.java
+++ b/src/main/java/com/T82/ticket/global/domain/repository/SeatRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
-    @Query("select s from Seat s where s.section.sectionId= :sectionId and s.isBooked= false and s.isChoicing= false")
-    List<Seat> findAllBySectionId(@Param("sectionId")Long sectionId);
+
 }

--- a/src/main/java/com/T82/ticket/global/domain/repository/SectionRepository.java
+++ b/src/main/java/com/T82/ticket/global/domain/repository/SectionRepository.java
@@ -1,5 +1,6 @@
 package com.T82.ticket.global.domain.repository;
 
+import com.T82.ticket.global.domain.entity.Seat;
 import com.T82.ticket.global.domain.entity.Section;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,7 @@ import java.util.List;
 public interface SectionRepository extends JpaRepository<Section, Long> {
     @Query("select s from Section s where s.place.eventId= :eventId")
     List<Section> findAllByEventId(@Param("eventId")Long evnetId);
+
+    @Query("SELECT s FROM Seat s JOIN s.section sec JOIN sec.place p WHERE p.eventId = :eventId AND s.isChoicing = false AND s.isBooked = false")
+    List<Seat> findAllSeatsByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/T82/ticket/service/SeatServiceImpl.java
+++ b/src/main/java/com/T82/ticket/service/SeatServiceImpl.java
@@ -4,6 +4,7 @@ import com.T82.ticket.dto.response.AvailableSeatsResponseDto;
 import com.T82.ticket.global.domain.entity.Seat;
 import com.T82.ticket.global.domain.exception.SectionNotFoundException;
 import com.T82.ticket.global.domain.repository.SeatRepository;
+import com.T82.ticket.global.domain.repository.SectionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,11 +15,11 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class SeatServiceImpl implements SeatService{
-    private final SeatRepository seatRepository;
+    private final SectionRepository sectionRepository;
     @Override
-    public List<AvailableSeatsResponseDto> getAvailableSeats(Long sectionId) {
-        List<Seat> allBySectionId = seatRepository.findAllBySectionId(sectionId);
-        if(allBySectionId.isEmpty()) throw new SectionNotFoundException();
-        return allBySectionId.stream().map(AvailableSeatsResponseDto::from).toList();
+    public List<AvailableSeatsResponseDto> getAvailableSeats(Long eventId) {
+        List<Seat> seats = sectionRepository.findAllSeatsByEventId(eventId);
+        if(seats.isEmpty()) throw new SectionNotFoundException();
+        return seats.stream().map(AvailableSeatsResponseDto::from).toList();
     }
 }

--- a/src/test/java/com/T82/ticket/service/SeatServiceImplTest.java
+++ b/src/test/java/com/T82/ticket/service/SeatServiceImplTest.java
@@ -34,7 +34,7 @@ class SeatServiceImplTest {
     @Autowired
     SeatServiceImpl seatService;
     private Section section;
-    private Long sectionId;
+    private Long evnetId;
     @BeforeEach
     void setUp() {
         Place place = new Place(1L, "장소1", "주소1", new ArrayList<>());
@@ -42,7 +42,7 @@ class SeatServiceImplTest {
         section = new Section(null, "구역이름1", 25L, 21L, 10000L, place, new ArrayList<>());
         sectionRepository.saveAndFlush(section);
 
-        sectionId = section.getSectionId();
+        evnetId = section.getPlace().getEventId();
 
         for (int i = 1; i <= 5; i++) {
             for (int j = 1; j <= 5; j++) {
@@ -63,7 +63,7 @@ class SeatServiceImplTest {
             seats.get(1).setIsBooked(true);
             seatRepository.saveAllAndFlush(seats);
 //    when
-            List<AvailableSeatsResponseDto> availableSeats = seatService.getAvailableSeats(sectionId);
+            List<AvailableSeatsResponseDto> availableSeats = seatService.getAvailableSeats(evnetId);
 //    then
             assertEquals(23,availableSeats.size());
         }
@@ -77,7 +77,7 @@ class SeatServiceImplTest {
             seats.get(2).setIsChoicing(true);
             seatRepository.saveAllAndFlush(seats);
 //    when
-            List<AvailableSeatsResponseDto> availableSeats = seatService.getAvailableSeats(sectionId);
+            List<AvailableSeatsResponseDto> availableSeats = seatService.getAvailableSeats(evnetId);
 //    then
             assertEquals(22,availableSeats.size());
         }


### PR DESCRIPTION
## 개요
예매 가능한 구역별 좌석 리스트 반환하는 기능의 api 스펙을 수정하였습니다.

## 주요 변경 사항
- api 스펙 변경
- sectionId를 받는것으로 진행했지만 path로 eventId를 받는것으로  변경
- 좌석에 대한 정보만 반환하는 스펙에서 좌석 + 구역에 대한 정보를 반환하는 것으로 수정
